### PR TITLE
Fix call to showCoords

### DIFF
--- a/Example-Code/Example-Code.ps1
+++ b/Example-Code/Example-Code.ps1
@@ -58,5 +58,5 @@ function showCoords($x, $y)
 
 #   No comma  |
 #             V
-showLatLon 123 456
+showCoords 123 456
 


### PR DESCRIPTION
The function was renamed to showCoords, but the calling code referenced
the old name!
